### PR TITLE
Ekr interop

### DIFF
--- a/Logging.cpp
+++ b/Logging.cpp
@@ -66,12 +66,12 @@ Log::DoLog(unsigned int cat, unsigned int level, MozQuic *m, uint64_t cid, const
   }
 
   if (!m || !m->mAppHandlesLogging) {
-    fprintf(stderr,"%06ld:%016lx ", MozQuic::Timestamp() % 1000000, useCid);
+    fprintf(stderr,"%06lld:%016llx ", MozQuic::Timestamp() % 1000000, useCid);
     vfprintf(stderr, fmt, paramList);
   }
   else if (m && m->mConnEventCB && m->mClosure) {
     char buffer[2048];
-    int used = snprintf(buffer, 2048, "%06ld: ", MozQuic::Timestamp() % 1000000);
+    int used = snprintf(buffer, 2048, "%06lld: ", MozQuic::Timestamp() % 1000000);
     if (used >= 2047) {
       return MOZQUIC_OK;
     }

--- a/TransportExtension.cpp
+++ b/TransportExtension.cpp
@@ -223,7 +223,7 @@ TransportExtension::DecodeClientTransportParameters(unsigned char *input, uint16
   Decode4ByteObject(input, offset, inputSize, _initialVersion);
   Decode2ByteObject(input, offset, inputSize, paramSize);
   assert(offset == 6);
-  if (paramSize < 30 || (offset + paramSize) > inputSize) {
+  if (paramSize < 22 || (offset + paramSize) > inputSize) {
     return MOZQUIC_ERR_GENERAL;
   }
   input = input + offset;

--- a/tests/qdrive/qdrive-client-test007.c
+++ b/tests/qdrive/qdrive-client-test007.c
@@ -52,7 +52,7 @@ int testEvent7(void *closure, uint32_t event, void *param)
     state.state++;
     state.time0 = Timestamp();
   }
-  
+
   if (event == MOZQUIC_EVENT_CONNECTED) {
     test_assert(state.state == 1);
     state.state++;
@@ -92,7 +92,7 @@ int testEvent7(void *closure, uint32_t event, void *param)
     }
     return MOZQUIC_OK;
   }
-  
+
   if (state.state == 4) {
     test_assert(state.ctr == 16000);
     test_assert(state.time1 > state.time0);
@@ -124,12 +124,12 @@ int testEvent7(void *closure, uint32_t event, void *param)
 
   if (state.state == 7) {
     test_assert(1);
-    fprintf(stderr,"test7 client timing1 %ld timing2 %ld\n",
+    fprintf(stderr,"test7 client timing1 %lld timing2 %lld\n",
             state.time1 - state.time0, state.time2 - state.time1);
     // assert that the backpressure version was at least 500ms slower
     // than the non backpressure version
     test_assert((state.time2 - state.time1) - (state.time1 - state.time0) > 500);
-    
+
     mozquic_destroy_connection(parentConnection);
     fprintf(stderr,"exit ok\n");
     exit(0);


### PR DESCRIPTION
I claim that the minimum transport parameters size is not 30, but 32. There are three mandatory parameters;  initial_max_stream_data(32 bit), initial_max_data(32 bit), and idle_timeout(16 bit) for a total of 10 bytes. Each of these has a two byte type and a two byte header, for a total of 22 bytes.